### PR TITLE
Add brochure generator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+brochure.html

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Mo1
+
+This repository provides a simple script to convert request and offer JSON files into an HTML brochure.
+
+## Usage
+
+1. Prepare two JSON files describing your requests and offers. You can use `sample_requests.json` and `sample_offers.json` as examples.
+2. Run the script:
+
+```bash
+python brochure.py requests.json offers.json brochure.html
+```
+
+The generated `brochure.html` can be opened in any web browser.

--- a/brochure.py
+++ b/brochure.py
@@ -1,0 +1,51 @@
+import json
+import sys
+from pathlib import Path
+
+
+def load_items(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def render_html(requests, offers):
+    html = [
+        '<html>',
+        '<head><meta charset="utf-8"><title>Brochure</title></head>',
+        '<body>',
+        '<h1>Requests</h1>'
+    ]
+    for item in requests:
+        html.append(f"<h2>{item['title']}</h2>")
+        description = item.get('description')
+        if description:
+            html.append(f"<p>{description}</p>")
+        price = item.get('price')
+        if price:
+            html.append(f"<p>Price: {price}</p>")
+    html.append('<h1>Offers</h1>')
+    for item in offers:
+        html.append(f"<h2>{item['title']}</h2>")
+        description = item.get('description')
+        if description:
+            html.append(f"<p>{description}</p>")
+        price = item.get('price')
+        if price:
+            html.append(f"<p>Price: {price}</p>")
+    html.append('</body></html>')
+    return '\n'.join(html)
+
+
+def main(requests_path, offers_path, output_path):
+    requests = load_items(requests_path)
+    offers = load_items(offers_path)
+    html = render_html(requests, offers)
+    Path(output_path).write_text(html, encoding='utf-8')
+    print(f"Brochure saved to {output_path}")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print("Usage: python brochure.py requests.json offers.json output.html")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/sample_offers.json
+++ b/sample_offers.json
@@ -1,0 +1,4 @@
+[
+  {"title": "Offer A", "description": "Supply 50 items", "price": "$500"},
+  {"title": "Offer B", "description": "Service B", "price": "$150"}
+]

--- a/sample_requests.json
+++ b/sample_requests.json
@@ -1,0 +1,4 @@
+[
+  {"title": "Request 1", "description": "Need 100 widgets", "price": "$1000"},
+  {"title": "Request 2", "description": "Looking for service", "price": "$200"}
+]


### PR DESCRIPTION
## Summary
- add Python script to build HTML brochure from request and offer JSON files
- include sample data and usage instructions in README

## Testing
- `python brochure.py sample_requests.json sample_offers.json brochure.html`


------
https://chatgpt.com/codex/tasks/task_e_68a5e0b00ab48332845bfaa2003b080a